### PR TITLE
Fix string default for ClassConverter

### DIFF
--- a/src/helpers/TypeHelper.ts
+++ b/src/helpers/TypeHelper.ts
@@ -79,6 +79,10 @@ export class TypeHelper {
             return `""`;
         }
 
+        if (field.type === "string") {
+            return `"${field.default}"`;
+        }
+
         if (Array.isArray(field.default) && field.default.length === 0) {
             return `[]`;
         }

--- a/test/data/avro/User.avsc
+++ b/test/data/avro/User.avsc
@@ -154,6 +154,12 @@
           ]
         }
       }
+    },
+    {
+      "name": "source",
+      "doc": "The source of this user's sign-up.",
+      "type": "string",
+      "default": "organic"
     }
   ]
 }

--- a/test/data/expected/User.ts.test
+++ b/test/data/expected/User.ts.test
@@ -35,6 +35,7 @@ export interface UserInterface {
     emailAddresses: EmailAddress[];
     twitterAccounts: TwitterAccount[];
     toDoItems: ToDoItem[];
+    source: string;
 }
 
 export class User extends BaseAvroRecord implements UserInterface {
@@ -220,6 +221,12 @@ export class User extends BaseAvroRecord implements UserInterface {
                     ]
                 }
             }
+        },
+        {
+            "name": "source",
+            "doc": "The source of this user's sign-up.",
+            "type": "string",
+            "default": "organic"
         }
     ]
 }
@@ -239,6 +246,7 @@ export class User extends BaseAvroRecord implements UserInterface {
     public emailAddresses!: EmailAddress[];
     public twitterAccounts!: TwitterAccount[];
     public toDoItems!: ToDoItem[];
+    public source: string = "organic";
 
     public schema(): object {
         return User.schema;


### PR DESCRIPTION
ClassConverter currently assigns string defaults without quote. This PR fixes that bug with a test.

Before:
```typescript
// User.ts
export class User extends BaseAvroRecord implements UserInterface {
  // ...
  public source: string = organic;
```

After:
```typescript
// User.ts
export class User extends BaseAvroRecord implements UserInterface {
  // ...
  public source: string = "organic";
```