### PR TITLE
Add protocol to RegistryClientConfig

### DIFF
--- a/src/components/Avro/schema_registry/CachedSchemaRegistryClient.ts
+++ b/src/components/Avro/schema_registry/CachedSchemaRegistryClient.ts
@@ -23,6 +23,7 @@ export class CachedSchemaRegistryClient implements SchemaRegistry {
             host: config.host,
             port: config.port,
             logger: (config.logger !== undefined) ? config.logger : this._defaultLogger,
+            protocol: config.protocol,
         };
         this.client = new RegistryClient(clientConfig);
     }


### PR DESCRIPTION
The protocol parameter is missing in the RegistryClientConfig for the Cached Schema Registry Client